### PR TITLE
Potential fix for code scanning alert no. 3: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/Season-1/Level-5/code.py
+++ b/Season-1/Level-5/code.py
@@ -28,15 +28,15 @@ class SHA256_hasher:
 
     # produces the password hash by combining password + salt because hashing
     def password_hash(self, password, salt):
-        password = binascii.hexlify(hashlib.sha256(password.encode()).digest())
-        password_hash = bcrypt.hashpw(password, salt)
+        password_bytes = password.encode()
+        password_hash = bcrypt.hashpw(password_bytes, salt)
         return password_hash.decode('ascii')
 
     # verifies that the hashed password reverses to the plain text version on verification
     def password_verification(self, password, password_hash):
-        password = binascii.hexlify(hashlib.sha256(password.encode()).digest())
+        password_bytes = password.encode()
         password_hash = password_hash.encode('ascii')
-        return bcrypt.checkpw(password, password_hash)
+        return bcrypt.checkpw(password_bytes, password_hash)
 
 class MD5_hasher:
 


### PR DESCRIPTION
Potential fix for [https://github.com/lrth06/skills-secure-code-game/security/code-scanning/3](https://github.com/lrth06/skills-secure-code-game/security/code-scanning/3)

To fix the problem, we should remove the unnecessary SHA-256 pre-hashing step and pass the raw password bytes directly to bcrypt. This means that in both the `password_hash` and `password_verification` methods of the `SHA256_hasher` class, we should replace the lines that hash the password with SHA-256 with lines that simply encode the password as bytes (e.g., `password.encode()`). This ensures that bcrypt receives the original password, allowing it to apply its own salt and work factor as intended. No additional imports or dependencies are needed, as bcrypt is already imported and used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
